### PR TITLE
fix: require Node 22.12+ to match wrangler and Vite 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
## Summary

Same Node engine mismatch as the wrangler upgrades in #63 (Copilot did not comment here, but the constraint is identical).

`wrangler@4.125.0` requires Node `>=22.0.0`, and Vite 8 requires `>=22.12.0` on the Node 22 line. Tighten `engines.node` from `^20.19.0 || >=22.12.0` to `>=22.12.0`.

CI already uses Node 22.

## Test plan

- [x] `engines.node` is `>=22.12.0`
- [ ] Confirm CI on Node 22 still passes

Made with [Cursor](https://cursor.com)