### PR TITLE
chore: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@1.4.1
+        uses: calibreapp/image-actions@1.5.0
         with:
           GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
           compressOnly: true
@@ -36,6 +36,6 @@ jobs:
       - name: Push Changes
         if: |
           steps.calibre.outputs.markdown != ''
-        uses: ad-m/github-push-action@v1.1.0
+        uses: ad-m/github-push-action@v1.3.0
         with:
           github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- `pnpm/action-setup` `v4` → `v6`
- `actions/setup-node` `v6` → `v7`
- `actions/deploy-pages` `v4` → `v5`
- `calibreapp/image-actions` `1.4.1` → `1.5.0`
- `ad-m/github-push-action` `v1.1.0` → `v1.3.0`

`checkout@v7`, `upload-pages-artifact@v5`, and `cloudflare/wrangler-action@v4` are already current.

## Test plan

- [ ] Confirm Pages and Cloudflare deploy workflows still start on `main`

Made with [Cursor](https://cursor.com)